### PR TITLE
Fix nextflow.config conda profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,6 @@ profiles {
     process.conda = "$baseDir/environment.yml"
     conda.enabled = true
     params.enable_conda = true
-    conda { createTimeout = "120 min" }
   }
   debug { process.beforeScript = 'echo $HOSTNAME' }
   test {


### PR DESCRIPTION
This is required, to make nextflow actually use conda in case of `-profile conda`